### PR TITLE
Add ENV_FUNCTION_VERSION parameter

### DIFF
--- a/LogzioShipper/__init__.py
+++ b/LogzioShipper/__init__.py
@@ -39,6 +39,7 @@ HEADERS = {"Content-Type": "application/json"}
 RETRY_WAIT_FIXED = 2  # seconds for retry delay
 ENV_MAX_TRIES = int(os.getenv('MAX_TRIES', 3))
 ENV_LOG_TYPE = os.getenv('LOG_TYPE', "eventHub")
+ENV_FUNCTION_VERSION = os.getenv('FUNCTION_VERSION', '1.0.0')
 
 # Thread and Queue Configuration
 ENV_THREAD_COUNT = int(os.getenv('THREAD_COUNT', 4))
@@ -135,8 +136,15 @@ def process_eventhub_message(event):
         logs = []
         for line in message_body.splitlines():
             log_entry = json.loads(line)
+            
+            # Append version number to log
+            log_entry['function_version'] = ENV_FUNCTION_VERSION
+
             # Check if this log entry contains nested logs under 'records'
             if 'records' in log_entry and isinstance(log_entry['records'], list):
+                for record in log_entry['records']:
+                    # Ensure nested logs also include the version number
+                    record['function_version'] = ENV_FUNCTION_VERSION
                 logs.extend(log_entry['records'])  # Add nested logs individually
             else:
                 logs.append(log_entry)

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ As an alternative to the Azure Template, you can use Terraform to set up your lo
 ---
 ## Changelog
 
+- 0.0.2:
+  * Added `ENV_FUNCTION_VERSION` parameter for dynamic versioning in ARM template and Terraform.
+
 - 0.0.1:
   * Initial release with Python Azure Function.
   * Implement log shipping to Logz.io.

--- a/deployments/azuredeploylogs.json
+++ b/deployments/azuredeploylogs.json
@@ -3,6 +3,13 @@
     "contentVersion": "v0.0.1",
     "parameters":
     {
+        "FunctionAppVersion": {
+            "type": "string",
+            "defaultValue": "1.0.0",
+            "metadata": {
+                "description": "The version of the function app being deployed."
+            }
+        },
         "FailedLogBackupContainer":
         {
             "defaultValue": "failedlogbackup",
@@ -226,6 +233,10 @@
                     "linuxFxVersion": "PYTHON|3.11",
                     "appSettings":
                     [
+                        {
+                            "name": "FUNCTION_VERSION",
+                            "value": "[parameters('FunctionAppVersion')]"
+                        },
                         {
                             "name": "FUNCTIONS_WORKER_RUNTIME",
                             "value": "python"

--- a/deployments/azuredeploylogs.tf
+++ b/deployments/azuredeploylogs.tf
@@ -101,6 +101,7 @@ resource "azurerm_linux_function_app" "function_app" {
   }
 
   app_settings = {
+    "FUNCTION_VERSION" = var.function_app_version
     "FUNCTIONS_WORKER_RUNTIME" = "python"
     "FUNCTIONS_EXTENSION_VERSION" = "~4"
     "AzureWebJobsEventHubConnectionString" = local.eventhub_connection_string

--- a/deployments/variables.tf
+++ b/deployments/variables.tf
@@ -1,3 +1,8 @@
+variable "function_app_version" {
+  description = "The version of the function app being deployed."
+  default     = "1.0.0"
+}
+
 variable "failed_log_backup_container" {
   description = "The name of the blob container within the storage account."
   default     = "failedlogbackup"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # Manually managing azure-functions-worker may cause unexpected issues
 
 # Azure Functions framework
-azure-functions==1.17.0
+azure-functions==1.18.0
 
 applicationinsights
 
@@ -11,5 +11,5 @@ applicationinsights
 azure-storage-blob==12.19.0
 
 # Utilities and helpers
-python-dotenv==1.0.0
+python-dotenv==1.0.1
 backoff==2.2.1


### PR DESCRIPTION
This PR introduces the `ENV_FUNCTION_VERSION` parameter into the ARM templateand Terraform to allow dynamic configuration of the function app version. 
This addition facilitates better version management and deployment practices by enabling version specification at deployment time.

By integrating `ENV_FUNCTION_VERSION`, we ensure that our deployments can be accurately tagged with their corresponding version, improving traceability and support for continuous integration and deployment workflows.
