### PR TITLE
Set FunctionAppVersion from contentVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ As an alternative to the Azure Template, you can use Terraform to set up your lo
 ---
 ## Changelog
 
+- 0.0.3:
+  * FunctionAppVersion now dynamically matches the ARM template's contentVersion.
+  
 - 0.0.2:
   * Added `ENV_FUNCTION_VERSION` parameter for dynamic versioning in ARM template and Terraform.
 

--- a/deployments/azuredeploylogs.json
+++ b/deployments/azuredeploylogs.json
@@ -5,7 +5,7 @@
     {
         "FunctionAppVersion": {
             "type": "string",
-            "defaultValue": "1.0.0",
+            "defaultValue": "[deployment().properties.template.contentVersion]",
             "metadata": {
                 "description": "The version of the function app being deployed."
             }


### PR DESCRIPTION
Align FunctionAppVersion with ARM contentVersion

Updated scripts to set `FunctionAppVersion` using the ARM template's `contentVersion`. 
Ensures version consistency across deployments.
